### PR TITLE
Fix require

### DIFF
--- a/lib/rudge.rb
+++ b/lib/rudge.rb
@@ -1,4 +1,4 @@
-require "rudge/abbreviations"
+require_relative "rudge/abbreviations"
 
 class Rudge
   # end of sentence marker (before and after whitespace)

--- a/test/test_regression.rb
+++ b/test/test_regression.rb
@@ -1,7 +1,7 @@
-require "test/unit"
+require "minitest/autorun"
 require_relative "../lib/rudge"
 
-class RudgeRegressionTest < Test::Unit::TestCase
+class RudgeRegressionTest < Minitest::Test
   def test_regression
     sentences = Rudge.sentences("Hello Project. Goodbye.")
 

--- a/test/test_regression.rb
+++ b/test/test_regression.rb
@@ -1,5 +1,5 @@
 require "test/unit"
-require "rudge"
+require_relative "../lib/rudge"
 
 class RudgeRegressionTest < Test::Unit::TestCase
   def test_regression

--- a/test/test_rudge.rb
+++ b/test/test_rudge.rb
@@ -1,7 +1,7 @@
-require "test/unit"
+require "minitest/autorun"
 require_relative "../lib/rudge"
 
-class RudgeTest < Test::Unit::TestCase
+class RudgeTest < Minitest::Test
   def test_one_sentence
     text      = "Hello World."
     sentences = Rudge.sentences(text)

--- a/test/test_rudge.rb
+++ b/test/test_rudge.rb
@@ -1,5 +1,5 @@
 require "test/unit"
-require "rudge"
+require_relative "../lib/rudge"
 
 class RudgeTest < Test::Unit::TestCase
   def test_one_sentence


### PR DESCRIPTION
Hi,

In my CI environment I was having an error `cannot load such file -- rudge/abbreviations` when running my cucumber tests so I've used require_relative to ensure that the library loads the correct files without worrying that other libraries/frameworks/app servers might be changing ruby's $LOAD_PATH.

Also, hope you don't mind but I've removed test unit in favor of minitest as test unit is being discontinued and left in the standard lib only to support legacy test suites.

Cheers,
